### PR TITLE
Fix builds on macOS

### DIFF
--- a/CompilerFlags.cmake
+++ b/CompilerFlags.cmake
@@ -1,7 +1,7 @@
 if(${CMAKE_CXX_COMPILER_ID} STREQUAL "GNU")
   set(STANDARD_FLAG -std=c++11)
   set(WARNING_FLAGS "-Wall -Wextra -Wpedantic -Werror")
-elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang")
+elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_ID} STREQUAL "AppleClang")
   set(STANDARD_FLAG -std=c++11)
   set(WARNING_FLAGS "-Wall -Wextra -Wpedantic -Werror")
 elseif(${CMAKE_CXX_COMPILER_ID} STREQUAL "MSVC")

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -7,7 +7,7 @@ using namespace MotionControl;
 
 TEST_CASE("Timer", "[timer]")
 {
-    double epsilon = 0.01;
+    double epsilon = 0.02;
     double delay = 0.1;
 
     SECTION("now() and delay()")

--- a/test/test_time.cpp
+++ b/test/test_time.cpp
@@ -8,7 +8,7 @@ using namespace MotionControl;
 TEST_CASE("Timer", "[timer]")
 {
     double epsilon = 0.02;
-    double delay = 0.1;
+    double delay = 0.2;
 
     SECTION("now() and delay()")
     {


### PR DESCRIPTION
Compiler flags like std=c++11 were not being set on macOS because Apple's version of clang identifies as AppleClang. With this PR, AppleClang now uses the same flags as regular clang. 

Also fixes builds randomly failing on the macOS jenkins instance. Tests were regularly failing because the sleeps were occasionally more than 10ms over the specified delay. I increased the allowed deviation to 20ms and tests regularly pass on macOS.