### PR TITLE
Add support for installing the library with make install

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,3 +24,9 @@ endif()
 if (${BUILD_TEST})
     add_subdirectory(test)
 endif()
+
+
+install(TARGETS motion_control
+        ARCHIVE DESTINATION lib)
+install(DIRECTORY include/motion_control
+        DESTINATION include)


### PR DESCRIPTION
This PR adds support for installing the library with `make install`

CMake will default to the 'correct' location on the system it's running on. On *nix, this means /usr/local. The user is free to change this by setting CMake's install prefix at runtime.